### PR TITLE
Redis db selector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -74,6 +72,6 @@ setup(
             "flake8>=7.1.1"
         ]
     },
-    python_requires='>3.5.2',
+    python_requires='>=3.9.19',
     zip_safe=False
 )

--- a/test/test_redis_api.py
+++ b/test/test_redis_api.py
@@ -52,6 +52,10 @@ def helper_manager_fixture():
         def add_hmap_test(self):
             """Init RedisApi"""
             assert self.obj.flush() is True
+
+            if isinstance(self.obj, RedisApi):
+                self.obj.init_db_meta()
+
             nb = self.obj.cli.hset(
                 name='data_test',
                 key='key_test_0',

--- a/vemonitor_m8/conf_manager/schemas/appConnectors_schema.json
+++ b/vemonitor_m8/conf_manager/schemas/appConnectors_schema.json
@@ -111,7 +111,7 @@
                         "description": "Redis AppConnector item db.",
                         "type": "integer",
                         "minimum": 0,
-                        "maximum": 16
+                        "maximum": 15
                     },
                     "password": {
                         "description": "Redis AppConnector item password.",

--- a/vemonitor_m8/conf_manager/schemas/appConnectors_schema.json
+++ b/vemonitor_m8/conf_manager/schemas/appConnectors_schema.json
@@ -103,7 +103,15 @@
                     },
                     "port": {
                         "description": "Redis AppConnector item port.",
-                        "type": "integer"
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535
+                    },
+                    "db": {
+                        "description": "Redis AppConnector item db.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 16
                     },
                     "password": {
                         "description": "Redis AppConnector item password.",

--- a/vemonitor_m8/workers/redis/README.dev.md
+++ b/vemonitor_m8/workers/redis/README.dev.md
@@ -3,11 +3,6 @@
 ## RedisCli
 
 ToDo: 
-- Redis current data base must be defined and not set to default.
-- Reference data must be added to identify `vemonitor_m8` data bases structures.
-- Before writing selected db must be analysed to ensure writing source,  
-  to avoid write in a existent db used by another process.
-
 
 ## HmapTimeSeriesApp
 


### PR DESCRIPTION
Changes:
- requires at least python 3.9.19 to run `vemonitor_m8`
- [Fix: Ensure that the Redis API does not write to an already used database.](https://github.com/vemonitor/vemonitor_m8/issues/28)